### PR TITLE
Improve handling of worker threads in main_action

### DIFF
--- a/gpncfg/deployment/__init__.py
+++ b/gpncfg/deployment/__init__.py
@@ -135,15 +135,12 @@ class FailedStateError(Exception):
 
 
 class DeployDriver(Action):
-    def __init__(self, cfg, exit, queue, id, alive):
-        log.debug(
-            "deploy driver started with args {}".format([self, exit, queue, id, alive])
-        )
+    def __init__(self, cfg, exit, queue, id):
+        log.debug("deploy driver started with args {}".format([self, exit, queue, id]))
         super().__init__(cfg, exit, f"worker#{id}")
         self.queue = queue
         self.id = id
         self.usecase = None
-        self.alive = alive
 
     def assert_prop(self, device, name):
         old = self.__getattribute__(name)
@@ -160,8 +157,6 @@ class DeployDriver(Action):
 
     def worker_loop(self, _):
         self.log.debug("hello world")
-        self.alive.set()
-        self.log.debug("alive set")
         try:
             self.worker_loop_actual()
         except Exception as e:

--- a/gpncfg/main_action/__init__.py
+++ b/gpncfg/main_action/__init__.py
@@ -54,6 +54,9 @@ def handle_worker_exits(pending, timeout):
         for result in done:
             log_worker_result(result)
 
+        if len(pending) == 0:
+            break
+
     if len(pending) > 0:
         raise TimeoutError("not all worker threads exited in time.")
 

--- a/gpncfg/main_action/__init__.py
+++ b/gpncfg/main_action/__init__.py
@@ -277,5 +277,5 @@ class MainAction:
                     if fut.running():
                         log.info(f"remaining device worker {fut} with id {fut.id}")
                     else:
-                        log.debug(f"remaining device worker {fut} with id {fut.id}")
+                        log.debug(f"exited worker {fut} with id {fut.id}")
                 os._exit(1)

--- a/gpncfg/main_action/__init__.py
+++ b/gpncfg/main_action/__init__.py
@@ -4,6 +4,7 @@ import logging
 import os
 import queue
 import shutil
+import sys
 import threading
 import time
 from concurrent import futures
@@ -239,14 +240,14 @@ class MainAction:
                 else:
                     log.info("received ^C, attempting clean shutdown.")
 
-                # tell worker threads to exit
-                log.debug("waiting for 6 minutes for workers to exit")
-                pool.shutdown(wait=360, cancel_futures=True)
-                log.debug("thread pool was sucessfully shut down")
+                log.debug("telling worker threads to stop")
+                # no new threads/futures can spawn
+                pool.shutdown(wait=False, cancel_futures=True)
+                # indicate to workers that they must exit
                 self.exit.set()
 
                 log.info(
-                    "waiting for worker threads to exit. this might take up to a minute"
+                    "waiting for worker threads to exit. this might take a while"
                 )
 
                 # wait for workers to finish and log their result
@@ -262,7 +263,7 @@ class MainAction:
 
                 # exit with non zero code if the main loop got interrupted by an error
                 if isinstance(e, Exception):
-                    exit(1)
+                    sys.exit(1)
             except (Exception, KeyboardInterrupt) as e:
                 log.fatal(
                     "main thread encountered error while trying to exit, force exiting now",

--- a/gpncfg/main_action/__init__.py
+++ b/gpncfg/main_action/__init__.py
@@ -40,14 +40,6 @@ def log_worker_result(task):
         log.debug(f"{name} completed with result {task.result(0)}")
 
 
-def log_action_result(task):
-    name = f"action thread {task.id}"
-    if exc := task.exception(0):
-        log.error(f"{name} encountered an error", exc_info=exc)
-    else:
-        log.error(f"{name} finished unexpectedly with result {task.result(0)}")
-
-
 class Alive:
     def __init__(self, id):
         self.id = id
@@ -181,7 +173,7 @@ class MainAction:
                 log.debug("main thread queries finished action workers")
                 done_action, futs_action = futures.wait(futs_action, timeout=0)
                 for fut in done_action:
-                    log_action_result(fut)
+                    log_worker_result(fut)
                     del queues[fut.id]
                 if self.cfg.daemon and done_action:
                     ids = []

--- a/gpncfg/main_action/__init__.py
+++ b/gpncfg/main_action/__init__.py
@@ -232,13 +232,13 @@ class MainAction:
             log.debug("preparing to handle an exception in main thread", exc_info=e)
             try:
                 # log why the main thread was interrupted
-                if isinstance(e, Exception):
+                if isinstance(e, KeyboardInterrupt):
+                    log.info("received ^C, attempting clean shutdown.")
+                else:
                     log.fatal(
                         "main thread encountered error",
                         exc_info=e,
                     )
-                else:
-                    log.info("received ^C, attempting clean shutdown.")
 
                 log.debug("telling worker threads to stop")
                 # no new threads/futures can spawn

--- a/gpncfg/main_action/__init__.py
+++ b/gpncfg/main_action/__init__.py
@@ -58,12 +58,6 @@ def handle_worker_exits(pending, timeout):
         raise TimeoutError("not all worker threads exited in time.")
 
 
-class Alive:
-    def __init__(self, id):
-        self.id = id
-        self.event = threading.Event()
-
-
 class MainAction:
     def __init__(self):
         logging.getLogger().addHandler(gpncfg.color_handler())
@@ -108,7 +102,6 @@ class MainAction:
         futs_action = set()
         queues = dict()
         pool = futures.ThreadPoolExecutor(max_workers=999)
-        alives = list()
         try:
             self.writer.spawn(pool, futs_action, queues)
             self.cleaner.spawn(pool, futs_action, queues)
@@ -143,21 +136,12 @@ class MainAction:
 
                     driver = deployment.DRIVERS.get(usecase)
                     if driver:
-                        alive = Alive(id)
                         task = pool.submit(
-                            driver(
-                                self.cfg, self.exit, queues[id], id, alive.event
-                            ).worker_loop,
+                            driver(self.cfg, self.exit, queues[id], id).worker_loop,
                             None,
                         )
                         task.id = id
                         futs_device.add(task)
-                        alives.append(alive)
-                        alive.event.wait(timeout=5)
-                        if not alive.event.is_set():
-                            raise Exception(
-                                f"wtf why did the worker not start within 5 seconds: {id}, we know about {len(futs_device)} + action threads"
-                            )
                     else:
                         missing_usecases.add(usecase)
 
@@ -207,10 +191,6 @@ class MainAction:
                     ids.append(f"<id: {fut.id} fut {fut}>")
 
                 log.debug(f"main thread knows about these device workers: {ids}")
-
-                for alive in alives:
-                    if not alive.event.is_set():
-                        log.warning(f"alive event for worker {alive.id} not set yet")
 
                 # only loop in daemon mode
                 if not self.cfg.daemon:


### PR DESCRIPTION
* wait a clearly defined time for workers to exit
* fix https://github.com/entropia/gpn-noc-gpncfg/issues/92
* improve logging output
* use sys.exit instead of exit
* deduplicate code
* remove alive confirmations, they are not useful