### PR TITLE
fiddle: fix broken slugify

### DIFF
--- a/gpncfg/fiddle/__init__.py
+++ b/gpncfg/fiddle/__init__.py
@@ -22,7 +22,9 @@ def slugify(text):
     """
     lower_text = text.lower()
     umlaut_free_text = lower_text.translate(TRANS_SLUG)
-    clean_text = re.sub("[^0-9a-zA-Z_-]+", "_", umlaut_free_text)
+    # we need to map " " to "-" in order to stay compatible with older slugs such as the usecase ones
+    compat_text = re.sub(r"\s", "-", umlaut_free_text)
+    clean_text = re.sub("r[^0-9a-zA-Z_-]+", "_", compat_text)
     dup_free_text = re.sub("_+", "_", clean_text)
     if not re.match("^[a-z]", dup_free_text):
         dup_free_text = "z" + dup_free_text


### PR DESCRIPTION
we used to replace " " by "-", the new implementation replaces all special characters with a "-"

to say compatible we replace " " with "-" again