### PR TITLE
Moep/fix hanging cli sessions

### DIFF
--- a/gpncfg/deployment/__init__.py
+++ b/gpncfg/deployment/__init__.py
@@ -354,7 +354,7 @@ class DeployJunos(DeployDriver):
         self.netcon_cfg_mode(netcon)
         if not self.cfg.dry_deploy:
             sts.update(device["nodename"], StatisticsType.CONFIRM)
-            self.netcon_cmd(netcon, "commit", read_timeout=120)
+            self.netcon_cmd(netcon, "commit check", read_timeout=120)
 
         self.log.debug("all done, disconnecting")
         netcon.disconnect()

--- a/gpncfg/deployment/__init__.py
+++ b/gpncfg/deployment/__init__.py
@@ -308,7 +308,9 @@ class DeployJunos(DeployDriver):
         self.netcon_cfg_mode(netcon)
 
         if not self.cfg.dry_deploy:
-            self.netcon_cmd(netcon, "load override /var/tmp/gpncfg-upload-new-uid.cfg")
+            self.netcon_cmd(
+                netcon, "load override /var/tmp/gpncfg-upload-new-uid.cfg | no-more"
+            )
 
         if self.is_change_more_than_motd(netcon):
             sts.update(device["nodename"], StatisticsType.UPDATE)


### PR DESCRIPTION
pipe the load output though no-more and use commit check to confirm (which causes less load on the device)